### PR TITLE
Support References the Schema Registry way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /export_env_cclouds.sh
 /testk8s.yml
 /apicurio-compose.yml
+/LICENSE

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
   - docker-compose up -d
   - go test
   - cd ../internals
+  - docker-compose -f ../integrationTests/docker-compose-internal.yml up -d
   - go test
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   - docker-compose up -d
   - go test
   - cd ../internals
-  - docker-compose -f ../integrationTests/docker-compose-internal.yml --env-file ../integrationTests/.env up -d
   - go test
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - docker-compose up -d
   - go test
   - cd ../internals
-  - docker-compose -f ../integrationTests/docker-compose-internal.yml up -d
+  - docker-compose -f ../integrationTests/docker-compose-internal.yml --env-file ../integrationTests/.env up -d
   - go test
 
 addons:

--- a/cmd/ccloud-schema-exporter/ccloud-schema-exporter.go
+++ b/cmd/ccloud-schema-exporter/ccloud-schema-exporter.go
@@ -127,7 +127,7 @@ func main() {
 		client.ThisRun == client.SYNC && client.SyncHardDeletes && !client.NoPrompt {
 
 		fmt.Println("It looks like you are trying to sync hard deletions between non-Confluent Cloud Schema Registries")
-		fmt.Println("Starting v1.1, ccloud-schema-exporter only supports hard deletion sync between Confluent Cloud Schema Registries")
+		fmt.Println("Starting v1.1, ccloud-schema-exporter only supports hard deletion sync between Confluent Cloud Schema Registries, or Confluent Platform 6.1+")
 		fmt.Println("------------------------------------------------------")
 		fmt.Println("Do you wish to continue? (Y/n)")
 
@@ -161,7 +161,7 @@ func main() {
 
 }
 
-func preflightWriteChecks (destClient *client.SchemaRegistryClient) {
+func preflightWriteChecks(destClient *client.SchemaRegistryClient) {
 
 	if !destClient.IsReachable() {
 		log.Println("Could not reach destination registry. Possible bad credentials?")

--- a/cmd/integrationTests/exporter-integration_test.go
+++ b/cmd/integrationTests/exporter-integration_test.go
@@ -65,8 +65,8 @@ func TestExportMode(t *testing.T) {
 	srcChan := make(chan map[string][]int64)
 	dstChan := make(chan map[string][]int64)
 
-	go testClientSrc.GetSubjectsWithVersions(srcChan)
-	go testClientDst.GetSubjectsWithVersions(dstChan)
+	go testClientSrc.GetSubjectsWithVersions(srcChan, false)
+	go testClientDst.GetSubjectsWithVersions(dstChan, false)
 
 	srcSubjects := <-srcChan
 	dstSubjects := <-dstChan
@@ -82,7 +82,7 @@ func TestExportMode(t *testing.T) {
 	client.DisallowList = nil
 
 	client.BatchExport(testClientSrc, testClientDst)
-	go testClientDst.GetSubjectsWithVersions(dstChan)
+	go testClientDst.GetSubjectsWithVersions(dstChan, false)
 	dstSubjects = <-dstChan
 
 	_, contains := dstSubjects[testingSubjectKey]
@@ -96,7 +96,7 @@ func TestExportMode(t *testing.T) {
 	//Get length of subjects without filters
 	client.AllowList = nil
 	client.DisallowList = nil
-	go testClientDst.GetSubjectsWithVersions(dstChan)
+	go testClientSrc.GetSubjectsWithVersions(dstChan, false)
 	dstSubjectsAll := <-dstChan
 
 	client.AllowList = nil
@@ -105,10 +105,12 @@ func TestExportMode(t *testing.T) {
 	}
 
 	client.BatchExport(testClientSrc, testClientDst)
-	go testClientDst.GetSubjectsWithVersions(dstChan)
+	go testClientDst.GetSubjectsWithVersions(dstChan, false)
 	dstSubjects = <-dstChan
 
 	_, contains = dstSubjects[testingSubjectKey]
+	log.Println(len(dstSubjectsAll))
+	log.Println(len(client.DisallowList))
 	assert.Equal(t, len(dstSubjectsAll)-len(client.DisallowList), len(dstSubjects))
 	assert.True(t, contains)
 }
@@ -126,6 +128,7 @@ func TestLocalMode(t *testing.T) {
 	testLocalCopy(t, registrationCount)
 
 	log.Println("Test Local Mode With Allow Lists!")
+	cleanup()
 
 	client.DisallowList = nil
 	client.AllowList = map[string]bool{
@@ -133,13 +136,14 @@ func TestLocalMode(t *testing.T) {
 	}
 
 	dstChan := make(chan map[string][]int64)
-	go testClientDst.GetSubjectsWithVersions(dstChan)
+	go testClientSrc.GetSubjectsWithVersions(dstChan, false)
 	dstSubjects := <-dstChan
+	log.Println(dstSubjects)
 
 	filteredSubjectCount := 0
 	for _, versions := range dstSubjects {
 		for _, _ = range versions {
-			filteredSubjectCount = filteredSubjectCount + 1
+			filteredSubjectCount++
 		}
 	}
 
@@ -147,19 +151,21 @@ func TestLocalMode(t *testing.T) {
 	testLocalCopy(t, filteredSubjectCount)
 
 	log.Println("Test Local Mode With Disallow Lists!")
+	cleanup()
 
 	client.AllowList = nil
 	client.DisallowList = map[string]bool{
 		testingSubjectValue: true,
 	}
 
-	go testClientDst.GetSubjectsWithVersions(dstChan)
+	go testClientSrc.GetSubjectsWithVersions(dstChan, false)
 	dstSubjects = <-dstChan
+	log.Println(dstSubjects)
 
 	filteredSubjectCount = 0
 	for _, versions := range dstSubjects {
 		for _, _ = range versions {
-			filteredSubjectCount = filteredSubjectCount + 1
+			filteredSubjectCount++
 		}
 	}
 
@@ -345,8 +351,8 @@ func testSoftDelete(t *testing.T, lenOfDestSubjects int) {
 
 	// Assert schemas in dest deep equal schemas in src
 
-	go testClientSrc.GetSubjectsWithVersions(srcChan)
-	go testClientDst.GetSubjectsWithVersions(destChan)
+	go testClientSrc.GetSubjectsWithVersions(srcChan, false)
+	go testClientDst.GetSubjectsWithVersions(destChan, false)
 
 	srcSubjects = <-srcChan
 	destSubjects = <-destChan
@@ -368,8 +374,8 @@ func testInitialSync(t *testing.T, lenOfDestSubjects int) {
 	srcChan := make(chan map[string][]int64)
 	destChan := make(chan map[string][]int64)
 
-	go testClientSrc.GetSubjectsWithVersions(srcChan)
-	go testClientDst.GetSubjectsWithVersions(destChan)
+	go testClientSrc.GetSubjectsWithVersions(srcChan, false)
+	go testClientDst.GetSubjectsWithVersions(destChan, false)
 
 	srcSubjects = <-srcChan
 	destSubjects = <-destChan
@@ -404,8 +410,8 @@ func testRegistrationSync(t *testing.T, lenOfDestSubjects int) {
 
 	// Assert schemas in dest deep equal schemas in src
 
-	go testClientSrc.GetSubjectsWithVersions(srcChan)
-	go testClientDst.GetSubjectsWithVersions(destChan)
+	go testClientSrc.GetSubjectsWithVersions(srcChan, false)
+	go testClientDst.GetSubjectsWithVersions(destChan, false)
 
 	srcSubjects = <-srcChan
 	destSubjects = <-destChan

--- a/cmd/integrationTests/exporter-integration_test.go
+++ b/cmd/integrationTests/exporter-integration_test.go
@@ -302,7 +302,7 @@ func setupSource() {
 	registerAtSource(schemaReferencing, "someReferencingSubject", 12346, 1, "AVRO", []client.SchemaReference{referenceStruct})
 }
 
-func registerAtSource (schema string, subject string, id int64, version int64, SType string, references []client.SchemaReference) {
+func registerAtSource(schema string, subject string, id int64, version int64, SType string, references []client.SchemaReference) {
 	log.Printf("Registering schema with subject %s, version %d, and id %d", subject, version, id)
 	testClientSrc.RegisterSchemaBySubjectAndIDAndVersion(schema, subject, id, version, SType, references)
 	registrationCount++

--- a/cmd/internals/customDestination.go
+++ b/cmd/internals/customDestination.go
@@ -63,7 +63,7 @@ func RunCustomDestinationBatch(srcClient *SchemaRegistryClient, customDest Custo
 	listenForInterruption()
 
 	srcChan := make(chan map[string][]int64)
-	go srcClient.GetSubjectsWithVersions(srcChan)
+	go srcClient.GetSubjectsWithVersions(srcChan, false)
 	srcSubjects := <-srcChan
 
 	log.Println("Registering all schemas from " + srcClient.SRUrl)

--- a/cmd/internals/customDestination_test.go
+++ b/cmd/internals/customDestination_test.go
@@ -21,7 +21,7 @@ func TestMainStackCustomDestination(t *testing.T) {
 
 func TCustomDestinationBatch(t *testing.T) {
 	log.Println("Testing Custom Destination in Batch Mode")
-	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, testingSubject, 10001, 1, "AVRO")
+	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, testingSubject, 10001, 1, "AVRO", []SchemaReference{})
 	myTestCustomDestination := NewSampleCustomDestination()
 
 	RunCustomDestinationBatch(testClient, &myTestCustomDestination)
@@ -39,7 +39,7 @@ func TCustomDestinationSync(t *testing.T) {
 	go RunCustomDestinationSync(testClient, &myTestCustomDestination)
 	time.Sleep(time.Duration(4) * time.Second) // Give time for sync
 
-	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, newSubject, 10001, 1, "AVRO")
+	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, newSubject, 10001, 1, "AVRO", []SchemaReference{})
 	time.Sleep(time.Duration(4) * time.Second) // Give time for sync
 	_, exists1 := myTestCustomDestination.inMemState[testingSubject]
 	_, exists2 := myTestCustomDestination.inMemState[newSubject]

--- a/cmd/internals/customSource_test.go
+++ b/cmd/internals/customSource_test.go
@@ -5,7 +5,6 @@ package client
 // Copyright 2020 Abraham Leal
 //
 
-
 import (
 	"github.com/stretchr/testify/assert"
 	"log"

--- a/cmd/internals/exportSchemas.go
+++ b/cmd/internals/exportSchemas.go
@@ -16,7 +16,7 @@ func BatchExport(srcClient *SchemaRegistryClient, destClient *SchemaRegistryClie
 
 	// Set up soft Deleted IDs in destination for interpretation by the destination registry
 	if SyncDeletes {
-		syncExistingSoftDeletedSubjects(srcClient,destClient)
+		syncExistingSoftDeletedSubjects(srcClient, destClient)
 	}
 
 	log.Println("Registering all schemas from " + srcClient.SRUrl)
@@ -26,13 +26,15 @@ func BatchExport(srcClient *SchemaRegistryClient, destClient *SchemaRegistryClie
 		}
 		for _, v := range srcVersions {
 			schema := srcClient.GetSchema(srcSubject, v, false)
+			RegisterReferences(schema, srcClient, destClient, false)
 			log.Printf("Registering schema: %s with version: %d and ID: %d and Type: %s",
 				schema.Subject, schema.Version, schema.Id, schema.SType)
 			destClient.RegisterSchemaBySubjectAndIDAndVersion(schema.Schema,
 				schema.Subject,
 				schema.Id,
 				schema.Version,
-				schema.SType)
+				schema.SType,
+				schema.References)
 		}
 	}
 }

--- a/cmd/internals/helpers.go
+++ b/cmd/internals/helpers.go
@@ -14,6 +14,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 )
 
@@ -36,6 +38,8 @@ func printVersion() {
 	fmt.Printf("ccloud-schema-exporter: %s\n", Version)
 }
 
+// Checks if the described path is a file
+// It will return false if the file does not exist or the given is a directory
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {
@@ -303,19 +307,19 @@ func GetIDDiff(m1 map[int64]map[string][]int64, m2 map[int64]map[string][]int64)
 				subjectRightVersions, subjectExistsRight := subjVersionsRightMap[subjectLeft]
 				if subjectExistsRight {
 					for _, singleVersionLeft := range versionsLeft { // Iterate through versions on left
-						if !isInSlice(singleVersionLeft, subjectRightVersions) {  // if not exists on right
+						if !isInSlice(singleVersionLeft, subjectRightVersions) { // if not exists on right
 							_, idInQueue := toDelete[idLeft]
 							if idInQueue {
 								_, subjectInQueue := toDelete[idLeft][subjectLeft]
 								if subjectInQueue {
-									toDelete[idLeft][subjectLeft] = append(toDelete[idLeft][subjectLeft],singleVersionLeft) // Add to holder for queueing for deletion
+									toDelete[idLeft][subjectLeft] = append(toDelete[idLeft][subjectLeft], singleVersionLeft) // Add to holder for queueing for deletion
 								} else {
 									tmpIDContents := toDelete[idLeft]
 									tmpIDContents[subjectLeft] = []int64{singleVersionLeft}
 									toDelete[idLeft] = tmpIDContents
 								}
 							} else {
-								tempMap := map[string][]int64{subjectLeft:{singleVersionLeft}}
+								tempMap := map[string][]int64{subjectLeft: {singleVersionLeft}}
 								toDelete[idLeft] = tempMap
 							}
 						}
@@ -327,7 +331,7 @@ func GetIDDiff(m1 map[int64]map[string][]int64, m2 map[int64]map[string][]int64)
 						tempMap[subjectLeft] = versionsLeft
 						toDelete[idLeft] = tempMap
 					} else {
-						toDelete[idLeft] = map[string][]int64{subjectLeft : versionsLeft}
+						toDelete[idLeft] = map[string][]int64{subjectLeft: versionsLeft}
 					}
 				}
 			}
@@ -365,4 +369,48 @@ func listenForInterruption() {
 		log.Printf("Received %v signal, quitting non-started schema writes...", sig)
 		CancelRun = true
 	}()
+}
+
+func RegisterReferences(wrappingSchema SchemaRecord, srcClient *SchemaRegistryClient, destClient *SchemaRegistryClient, deleted bool) {
+	if len(wrappingSchema.References) != 0 {
+		log.Printf("Registering references for subject %s and version %d", wrappingSchema.Subject, wrappingSchema.Version)
+		for _, schemaReference := range wrappingSchema.References {
+			schema := srcClient.GetSchema(schemaReference.Subject, schemaReference.Version, deleted)
+
+			schemaAlreadyRegistered := new(SchemaAlreadyRegisteredResponse)
+
+			responseBody := destClient.RegisterSchemaBySubjectAndIDAndVersion(schema.Schema,
+				schema.Subject,
+				schema.Id,
+				schema.Version,
+				schema.SType,
+				schema.References)
+
+			err := json.Unmarshal(responseBody, &schemaAlreadyRegistered)
+
+			if err == nil {
+				log.Printf("Reference schema subject %s was already written with version: %d and ID: %d", schema.Subject, schema.Version, schema.Id)
+			} else {
+				log.Printf("Registering referenced schema: %s with version: %d and ID: %d and Type: %s",
+					schema.Subject, schema.Version, schema.Id, schema.SType)
+			}
+		}
+	}
+}
+
+func RegisterReferencesFromLocalFS(referencesToRegister []SchemaReference, dstClient *SchemaRegistryClient, pathToLookForReferences string) {
+
+	err := filepath.Walk(pathToLookForReferences,
+		func(path string, info os.FileInfo, err error) error {
+			check(err)
+			for _, oneRef := range referencesToRegister {
+				if !info.IsDir() && strings.Contains(info.Name(), fmt.Sprintf("%s-%d", oneRef.Subject, oneRef.Version)) {
+					log.Println(fmt.Sprintf("Writing referenced schema with Subject: %s and Version: %d. Filepath: %s", oneRef.Subject, oneRef.Version, path))
+					writeSchemaToSR(dstClient, path)
+				}
+			}
+
+			return nil
+		})
+	check(err)
 }

--- a/cmd/internals/helpers_test.go
+++ b/cmd/internals/helpers_test.go
@@ -22,14 +22,14 @@ func TestMainStackHelpers(t *testing.T) {
 	t.Run("TGetIDDiff", func(t *testing.T) { TGetIDDiff(t) })
 }
 
-func TisInSlice (t *testing.T) {
-	sliceOne := []int64{1,2,3,4,5}
+func TisInSlice(t *testing.T) {
+	sliceOne := []int64{1, 2, 3, 4, 5}
 
 	assert.True(t, isInSlice(3, sliceOne))
 	assert.True(t, !isInSlice(6, sliceOne))
 }
 
-func TcheckSubjectIsAllowed (t *testing.T) {
+func TcheckSubjectIsAllowed(t *testing.T) {
 	AllowList = map[string]bool{
 		"testingSubjectKey": true,
 		"SomeOtherValue":    true,
@@ -48,8 +48,7 @@ func TcheckSubjectIsAllowed (t *testing.T) {
 
 }
 
-
-func TfilterListedSubjects (t *testing.T) {
+func TfilterListedSubjects(t *testing.T) {
 
 	AllowList = map[string]bool{
 		"testingSubjectKey": true,
@@ -74,10 +73,10 @@ func TfilterListedSubjects (t *testing.T) {
 	AllowList = nil
 	DisallowList = nil
 
-	assert.True(t, reflect.DeepEqual(result,expected))
+	assert.True(t, reflect.DeepEqual(result, expected))
 }
 
-func TfilterListedSubjectsVersions (t *testing.T) {
+func TfilterListedSubjectsVersions(t *testing.T) {
 	AllowList = map[string]bool{
 		"testingSubjectKey": true,
 		"SomeOtherValue":    true,
@@ -103,91 +102,91 @@ func TfilterListedSubjectsVersions (t *testing.T) {
 	AllowList = nil
 	DisallowList = nil
 
-	assert.True(t, reflect.DeepEqual(result,expected))
+	assert.True(t, reflect.DeepEqual(result, expected))
 
 }
 
-func TfilterIDs (t *testing.T) {
+func TfilterIDs(t *testing.T) {
 
 	AllowList = map[string]bool{
 		"testingSubjectKey": true,
-		"SomeOtherValue" : true,
+		"SomeOtherValue":    true,
 	}
 
 	DisallowList = map[string]bool{
 		"someValuePartTwo": true,
-		"SomeOtherValue" : true,
+		"SomeOtherValue":   true,
 	}
 
 	toFilter := map[int64]map[string][]int64{
-		1001: {"testingSubjectKey" : {1,2,3}, "someValuePartTwo" : {1,2}},
-		5000: {"SomeOtherValue" : {1,2}},
+		1001: {"testingSubjectKey": {1, 2, 3}, "someValuePartTwo": {1, 2}},
+		5000: {"SomeOtherValue": {1, 2}},
 	}
 
 	result := filterIDs(toFilter)
 
 	expected := map[int64]map[string][]int64{
-		1001: {"testingSubjectKey" : {1,2,3}},
+		1001: {"testingSubjectKey": {1, 2, 3}},
 	}
 
 	AllowList = nil
 	DisallowList = nil
 
-	assert.True(t, reflect.DeepEqual(result,expected))
+	assert.True(t, reflect.DeepEqual(result, expected))
 }
 
-func TGetSubjectDiff (t *testing.T) {
+func TGetSubjectDiff(t *testing.T) {
 	subjectMapOne := map[string][]int64{
-		"someValue" : {1,2,3},
-		"SomeOtherValue" : {1,2},
+		"someValue":      {1, 2, 3},
+		"SomeOtherValue": {1, 2},
 	}
 
 	subjectMapTwo := map[string][]int64{
-		"someValue" : {1,3},
-		"SomeOtherValue" : {2},
+		"someValue":      {1, 3},
+		"SomeOtherValue": {2},
 	}
 
-	result := GetSubjectDiff(subjectMapOne,subjectMapTwo)
+	result := GetSubjectDiff(subjectMapOne, subjectMapTwo)
 
 	expected := map[string][]int64{
-		"someValue" : {2},
-		"SomeOtherValue" : {1},
+		"someValue":      {2},
+		"SomeOtherValue": {1},
 	}
 
 	// Assert values that are contained in left but not right are returned
-	assert.True(t,reflect.DeepEqual(expected,result))
+	assert.True(t, reflect.DeepEqual(expected, result))
 }
 
 func TGetVersionsDiff(t *testing.T) {
-	versionArrayOne := []int64{1,2,3}
-	versionArrayTwo := []int64{1,3}
+	versionArrayOne := []int64{1, 2, 3}
+	versionArrayTwo := []int64{1, 3}
 
-	result := GetVersionsDiff(versionArrayOne,versionArrayTwo)
+	result := GetVersionsDiff(versionArrayOne, versionArrayTwo)
 
 	expected := []int64{2}
 
 	// Assert values that are contained in left but not right are returned
-	assert.Equal(t,expected,result)
+	assert.Equal(t, expected, result)
 }
 
-func TGetIDDiff (t *testing.T) {
+func TGetIDDiff(t *testing.T) {
 
 	idMapOne := map[int64]map[string][]int64{
-		1001: {"someValue" : {1,2,3}, "someValuePartTwo" : {1,2}},
-		5000: {"SomeOtherValue" : {1,2}},
+		1001: {"someValue": {1, 2, 3}, "someValuePartTwo": {1, 2}},
+		5000: {"SomeOtherValue": {1, 2}},
 	}
 
 	idMapTwo := map[int64]map[string][]int64{
-		1001: {"someValue" : {1,3}, "someValuePartTwo" : {1}},
-		5000: {"SomeOtherValue" : {2}},
+		1001: {"someValue": {1, 3}, "someValuePartTwo": {1}},
+		5000: {"SomeOtherValue": {2}},
 	}
 
 	results := GetIDDiff(idMapOne, idMapTwo)
 
 	expected := map[int64]map[string][]int64{
-		1001: {"someValue" : {2}, "someValuePartTwo" : {2}},
-		5000: {"SomeOtherValue" : {1}},
+		1001: {"someValue": {2}, "someValuePartTwo": {2}},
+		5000: {"SomeOtherValue": {1}},
 	}
 
-	assert.True(t, reflect.DeepEqual(expected,results))
+	assert.True(t, reflect.DeepEqual(expected, results))
 }

--- a/cmd/internals/meta.go
+++ b/cmd/internals/meta.go
@@ -33,6 +33,7 @@ var CancelRun bool
 var WithMetrics bool
 var AllowList StringArrayFlag
 var DisallowList StringArrayFlag
+var ReferenceSeparator = "=====References====="
 
 // Define RunMode Enum
 type RunMode int

--- a/cmd/internals/schema-registry-light-client.go
+++ b/cmd/internals/schema-registry-light-client.go
@@ -488,7 +488,7 @@ func (src *SchemaRegistryClient) getSchemaList(deleted bool) map[int64]map[strin
 
 func (src *SchemaRegistryClient) subjectExists(subject string) bool {
 	endpoint := fmt.Sprintf("%s/subjects/%s", src.SRUrl, subject)
-	sbjReq := GetNewRequest("GET", endpoint, src.SRApiKey,src.SRApiSecret, nil,nil)
+	sbjReq := GetNewRequest("GET", endpoint, src.SRApiKey, src.SRApiSecret, nil, nil)
 	response, err := httpClient.Do(sbjReq)
 	check(err)
 	defer response.Body.Close()

--- a/cmd/internals/schema-registry-light-client_test.go
+++ b/cmd/internals/schema-registry-light-client_test.go
@@ -41,7 +41,7 @@ func TestMainStack(t *testing.T) {
 	t.Run("TFilterListedSubjectsVersions", func(t *testing.T) { TFilterListedSubjectsVersions(t) })
 	t.Run("TPerformSoftDelete", func(t *testing.T) { TPerformSoftDelete(t) })
 	t.Run("TPerformHardDelete", func(t *testing.T) { TPerformHardDelete(t) })
-	t.Run("TGetSoftDeletedIds", func(t *testing.T) { TPerformHardDelete(t) })
+	t.Run("TGetSoftDeletedIds", func(t *testing.T) { TGetSoftDeletedIDs(t) })
 	t.Run("TDeleteAllSubjectsPermanently", func(t *testing.T) { TDeleteAllSubjectsPermanently(t) })
 	tearDown()
 }
@@ -117,7 +117,7 @@ func TIsImportModeReady(t *testing.T) {
 }
 
 func TGetSubjectWithVersions(t *testing.T) {
-	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, testingSubject, 10001, 1, "AVRO")
+	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, testingSubject, 10001, 1, "AVRO", []SchemaReference{})
 
 	aChan := make(chan map[string][]int64)
 	go testClient.GetSubjectsWithVersions(aChan)
@@ -145,13 +145,13 @@ func TGetVersions(t *testing.T) {
 }
 
 func TGetSchema(t *testing.T) {
-	record := testClient.GetSchema(testingSubject, 1,false)
+	record := testClient.GetSchema(testingSubject, 1, false)
 	assert.Equal(t, mockSchema, record.Schema)
 }
 
 func TRegisterSchemaBySubjectAndIDAndVersion(t *testing.T) {
-	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, newSubject, 10001, 1, "AVRO")
-	record := testClient.GetSchema(newSubject, 1,false)
+	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, newSubject, 10001, 1, "AVRO", []SchemaReference{})
+	record := testClient.GetSchema(newSubject, 1, false)
 	assert.Equal(t, mockSchema, record.Schema)
 
 	testClient.PerformSoftDelete(newSubject, 1)
@@ -159,7 +159,7 @@ func TRegisterSchemaBySubjectAndIDAndVersion(t *testing.T) {
 }
 
 func TGetSoftDeletedIDs(t *testing.T) {
-	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, newSubject, 10001, 1, "AVRO")
+	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, newSubject, 10001, 1, "AVRO", []SchemaReference{})
 	testClient.PerformSoftDelete(newSubject, 1)
 	result := testClient.GetSoftDeletedIDs()
 	expected := map[int64]map[string]int64{

--- a/cmd/internals/schema-registry-light-client_test.go
+++ b/cmd/internals/schema-registry-light-client_test.go
@@ -120,7 +120,7 @@ func TGetSubjectWithVersions(t *testing.T) {
 	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, testingSubject, 10001, 1, "AVRO", []SchemaReference{})
 
 	aChan := make(chan map[string][]int64)
-	go testClient.GetSubjectsWithVersions(aChan)
+	go testClient.GetSubjectsWithVersions(aChan, false)
 	result := <-aChan
 
 	assert.NotNil(t, result[testingSubject])
@@ -131,7 +131,7 @@ func TGetVersions(t *testing.T) {
 	var aGroup sync.WaitGroup
 
 	aChan := make(chan SubjectWithVersions)
-	go testClient.GetVersions(testingSubject, aChan, &aGroup)
+	go testClient.GetVersions(testingSubject, aChan, &aGroup, false)
 	aGroup.Add(1)
 	result := <-aChan
 	aGroup.Wait()

--- a/cmd/internals/schema-registry-light-client_test.go
+++ b/cmd/internals/schema-registry-light-client_test.go
@@ -59,6 +59,7 @@ func setup() {
 
 func tearDown() {
 	composeEnv.WithCommand([]string{"down", "-v"}).Invoke()
+	time.Sleep(time.Duration(10) * time.Second) // give services time to set up
 }
 
 func TIsReachable(t *testing.T) {

--- a/cmd/internals/schema-registry-light-client_test.go
+++ b/cmd/internals/schema-registry-light-client_test.go
@@ -162,8 +162,8 @@ func TGetSoftDeletedIDs(t *testing.T) {
 	testClient.RegisterSchemaBySubjectAndIDAndVersion(mockSchema, newSubject, 10001, 1, "AVRO", []SchemaReference{})
 	testClient.PerformSoftDelete(newSubject, 1)
 	result := testClient.GetSoftDeletedIDs()
-	expected := map[int64]map[string]int64{
-		10001: {newSubject: 1}}
+	expected := map[int64]map[string][]int64{
+		10001: {newSubject: {1}}}
 
 	testClient.PerformHardDelete(newSubject, 1)
 	assert.Equal(t, expected, result)


### PR DESCRIPTION
Up until this PR, `ccloud-schema-exporter` supported references the AVRO way: The complete avsc must have them rendered out. Schema Registry handles them a bit different.

This PR introduces reference support the SR way in all aspects of the tool.